### PR TITLE
Fix module import with int fields

### DIFF
--- a/vtlib/Vtiger/PackageImport.php
+++ b/vtlib/Vtiger/PackageImport.php
@@ -715,7 +715,7 @@ class PackageImport extends PackageExport
 		$fieldInstance->readonly = (int) $fieldnode->readonly;
 		$fieldInstance->presence = (int) $fieldnode->presence;
 		$fieldInstance->defaultvalue = (string) $fieldnode->defaultvalue;
-		$fieldInstance->maximumlength = (int) $fieldnode->maximumlength;
+		$fieldInstance->maximumlength = (string) $fieldnode->maximumlength;
 		$fieldInstance->sequence = (int) $fieldnode->sequence;
 		$fieldInstance->quickcreate = (int) $fieldnode->quickcreate;
 		$fieldInstance->quicksequence = (int) $fieldnode->quickcreatesequence;


### PR DESCRIPTION
when you import a module with an int field the int-maximumlenght is described as -2147483648,2147483647. Converting this string to a n int results in -2147483648.
So After the import of the module you cant enter positive values into the field

